### PR TITLE
build: add production compose files

### DIFF
--- a/circuit-generator/compose.prod.yaml
+++ b/circuit-generator/compose.prod.yaml
@@ -1,0 +1,12 @@
+services:
+  app:
+    image: public.ecr.aws/docker/library/node:20-alpine
+    working_dir: /app
+    volumes:
+      - ./:/app
+    entrypoint: ["sh", "/app/docker-entrypoint.sh"]
+    environment:
+      PORT: 3000
+    ports:
+      - "3000:3000"
+

--- a/circuit-generator/docker-entrypoint.sh
+++ b/circuit-generator/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Install production dependencies
+npm ci --omit=dev
+
+# Initialize database file if missing
+if [ ! -f database.json ]; then
+  echo '{"collection": {}}' > database.json
+fi
+
+# Build CSS assets
+npm run build:css
+
+exec node src/server.js

--- a/daily-organizer/assets/app.css
+++ b/daily-organizer/assets/app.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/daily-organizer/compose.prod.yaml
+++ b/daily-organizer/compose.prod.yaml
@@ -1,0 +1,59 @@
+services:
+  php:
+    image: public.ecr.aws/ids/php:8.3-fpm-alpine
+    working_dir: /var/www/html
+    environment:
+      APP_ENV: prod
+      DATABASE_URL: postgresql://${DB_USER:-app}:${DB_PASSWORD:-!ChangeMe!}@postgres:5432/${DB_NAME:-app}?serverVersion=16&charset=utf8
+      MESSENGER_TRANSPORT_DSN: redis://redis:6379/messages
+    volumes:
+      - ./:/var/www/html
+    entrypoint: ["sh", "/var/www/html/docker-entrypoint.sh"]
+    depends_on:
+      - postgres
+      - redis
+    networks:
+      - app_network
+
+  caddy:
+    image: public.ecr.aws/docker/library/caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./:/srv:ro
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+    depends_on:
+      - php
+    networks:
+      - app_network
+
+  postgres:
+    image: public.ecr.aws/docker/library/postgres:16-alpine
+    environment:
+      POSTGRES_DB: ${DB_NAME:-app}
+      POSTGRES_USER: ${DB_USER:-app}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-!ChangeMe!}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - app_network
+
+  redis:
+    image: public.ecr.aws/docker/library/redis:7-alpine
+    ports:
+      - "6379:6379"
+    networks:
+      - app_network
+
+volumes:
+  db_data:
+  caddy_data:
+
+networks:
+  app_network:
+    driver: bridge

--- a/daily-organizer/docker-entrypoint.sh
+++ b/daily-organizer/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Install PHP dependencies
+composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist
+
+# Install Node dependencies and build assets
+if command -v npm >/dev/null 2>&1; then
+  npm ci --omit=dev
+  npm run build
+fi
+
+# Initialize database and run migrations
+php bin/console doctrine:database:create --if-not-exists --no-interaction
+php bin/console doctrine:migrations:migrate --no-interaction
+
+exec php-fpm -F

--- a/daily-organizer/package.json
+++ b/daily-organizer/package.json
@@ -7,6 +7,7 @@
     "test": "tests"
   },
   "scripts": {
+    "build": "tailwindcss -i ./assets/app.css -o ./public/build/app.css --minify",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add production compose for circuit-generator
- add production compose for daily-organizer
- run asset builds via entrypoint scripts in production
- install dependencies and initialize databases at startup

## Motivation
Provide production-ready Docker Compose stacks using optimized images.

## Changes
- add compose.prod.yaml for circuit-generator
- add compose.prod.yaml for daily-organizer
- build assets via entrypoint scripts before starting services
- install dependencies and run database migrations on container boot

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change)
- [ ] ✨ New feature (non-breaking change)
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring
- [x] 🎨 Style/formatting
- [ ] ✅ Test improvement

## Testing
- `npm test`
- `composer qa` *(fails: ServiceNotFound `App\Domain\User\UserService`)*

## Checklist
- [x] Code follows project standards
- [x] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated
- [ ] No new warnings/errors
- [x] Semantic commit format used

## Related Issues

## Additional Notes
Attempted to run project QA; phpunit reports missing service `App\Domain\User\UserService`.


------
https://chatgpt.com/codex/tasks/task_e_6898ee92f56883338e79b3152a3ce065